### PR TITLE
Added self-host section and other stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # auto-cat
 🐈 A moderation bot for my server (Catbot's Guild)
+
+## Self-host
+This bot is hosted on heroku, meaning: 
+
+**-** It is not self-hosted
+**-** We will not help with self-hosting. The support server is for Catbot support only.
+**-** You cannot use the same name or icon. This is in violation of our copyright laws.
+**-** We won't stop you trying to self-host, feel free to, but we won't help you if you need help or mess up.
+
+With this being said, you're free to self-host this if you know what you're doing but we won't provide support for this specific area.


### PR DESCRIPTION
Please. This is not a bad change. I will not be upset if you don't merge but it's good in terms of licensing. So, please.

I added:
```
## Self-host
This bot is hosted on heroku, meaning: 

**-** It is not self-hosted
**-** We will not help with self-hosting. The support server is for Catbot support only.
**-** You cannot use the same name or icon. This is in violation of our copyright laws.
**-** We won't stop you trying to self-host, feel free to, but we won't help you if you need help or mess up.

With this being said, you're free to self-host this if you know what you're doing but we won't provide support for this specific area.
```